### PR TITLE
Add resilient-test module and publishing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,112 @@ setContent { ResilientExample() }
 - Cache only idempotent reads; set TTL appropriately.
 - Always observe telemetry (including CacheHit/CacheMiss, FallbackTriggered) for visibility and tuning.
 
+## Testing with `resilient-test`
+
+The `resilient-test` module provides utilities for testing resilience policies with fault injection and simplified policy builders.
+
+### Fault Injection
+
+Use `FaultInjector` to simulate failures, delays, and intermittent behavior in your tests:
+
+```kotlin
+import com.santimattius.resilient.test.FaultInjector
+import kotlin.time.Duration.Companion.milliseconds
+
+val injector = FaultInjector.builder()
+    .failureRate(0.3)           // 30% chance of failure
+    .delay(50.milliseconds)      // Add 50ms delay
+    .delayJitter(true)           // Randomize delay ±20%
+    .exception { CustomException() }  // Custom exception
+    .build()
+
+val result = injector.execute {
+    fetchData() // may throw or delay
+}
+```
+
+**Configuration:**
+- `failureRate(rate: Double)`: Probability of throwing an exception (0.0 = never, 1.0 = always).
+- `exception(block: () -> Throwable)`: Factory for the exception to throw (default: `FaultInjectedException`).
+- `delay(duration: Duration)`: Fixed delay before executing the block (default: `Duration.ZERO`).
+- `delayJitter(enable: Boolean)`: Randomize delay ±20% (default: `false`).
+
+### Policy Builders for Tests
+
+Use `PolicyBuilders` to create policies with sensible test defaults:
+
+```kotlin
+import com.santimattius.resilient.test.PolicyBuilders
+import com.santimattius.resilient.test.TestResilientScope
+import kotlinx.coroutines.test.runTest
+
+@Test
+fun `test retry with fault injection`() = runTest {
+    val scope = TestResilientScope(this)
+    val policy = PolicyBuilders.retryPolicy(
+        scope,
+        maxAttempts = 3,
+        initialDelay = 10.milliseconds
+    )
+    
+    val injector = FaultInjector.builder()
+        .failureRate(0.5)
+        .build()
+    
+    val result = policy.execute {
+        injector.execute { "success" }
+    }
+    
+    assertEquals("success", result)
+}
+```
+
+**Available builders:**
+- `retryPolicy(scope, maxAttempts = 3, initialDelay = 10ms, maxDelay = 100ms, shouldRetry = { true })`
+- `timeoutPolicy(scope, timeout = 1.second)`
+- `circuitBreakerPolicy(scope, failureThreshold = 3, successThreshold = 2, timeout = 5.seconds)`
+- `bulkheadPolicy(scope, maxConcurrentCalls = 2, maxWaitingCalls = 4)`
+- `rateLimiterPolicy(scope, maxCalls = 5, period = 1.second)`
+
+### TestResilientScope
+
+Use `TestResilientScope` to create a test-friendly scope for policies:
+
+```kotlin
+import com.santimattius.resilient.test.TestResilientScope
+import kotlinx.coroutines.test.runTest
+
+@Test
+fun `test policy lifecycle`() = runTest {
+    val scope = TestResilientScope(this)
+    val policy = resilient(scope) {
+        retry { maxAttempts = 3 }
+    }
+    
+    // ... test logic
+    
+    scope.cancel() // cleanup
+}
+```
+
+### Gradle Dependency
+
+Add the `resilient-test` module to your test dependencies:
+
+```kotlin
+// build.gradle.kts
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation("io.github.santimattius.resilient:resilient-test:1.3.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+        }
+    }
+}
+```
+
 ## Testing Notes
-- Use kotlinx-coroutines-test for virtual time.
+- Use `kotlinx-coroutines-test` for virtual time with `runTest` and `TestTimeSource`.
+- Use `FaultInjector` to simulate realistic failure scenarios (intermittent errors, slow responses).
 - Verify: retry attempts and delays, CB transitions, RL windows, BH limits, composition order, cancellation propagation, telemetry.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,12 +6,12 @@ android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
 
-composeBom = "2026.02.00"
+composeBom = "2026.03.00"
 androidx-lifecycle = "2.10.0"
 
-androidx-activity = "1.12.4"
+androidx-activity = "1.13.0"
 androidx-appcompat = "1.7.1"
-androidx-core = "1.17.0"
+androidx-core = "1.18.0"
 
 androidx-espresso = "3.7.0"
 androidx-testExt = "1.3.0"

--- a/gradle/resilient-maven-publishing.gradle
+++ b/gradle/resilient-maven-publishing.gradle
@@ -1,0 +1,42 @@
+// Shared Maven Central / signing / POM for io.github.santimattius.resilient modules.
+// Before applying, set: ext.resilientMavenArtifactId = "artifact-name"
+
+def artifactId = findProperty("resilientMavenArtifactId")?.toString()?.trim()
+if (!artifactId) {
+    throw new GradleException(
+        "Set ext[\"resilientMavenArtifactId\"] (or resilientMavenArtifactId in gradle.properties) before applying resilient-maven-publishing.gradle"
+    )
+}
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+    coordinates(project.group.toString(), artifactId, project.version.toString())
+
+    pom {
+        name = findProperty("resilientMavenPomName") ?: "Resilient Kotlin Multiplatform Library"
+        description = findProperty("resilientMavenPomDescription")
+            ?: "A Kotlin Multiplatform library providing resilience patterns (Timeout, Retry, Circuit Breaker, Rate Limiter, Bulkhead, Hedging, Cache, Fallback) for suspend functions."
+        inceptionYear = "2025"
+        url = "https://github.com/santimattius/kmp-resilient/"
+        licenses {
+            license {
+                name = "The Apache License, Version 2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                distribution = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+            }
+        }
+        developers {
+            developer {
+                id = "santiago-mattiauda"
+                name = "Santiago Mattiauda"
+                url = "https://github.com/santimattius"
+            }
+        }
+        scm {
+            url = "https://github.com/santimattius/kmp-resilient/"
+            connection = "scm:git:git://github.com/santimattius/kmp-resilient.git"
+            developerConnection = "scm:git:ssh://git@github.com/santimattius/kmp-resilient.git"
+        }
+    }
+}

--- a/resilient-test/README.md
+++ b/resilient-test/README.md
@@ -1,0 +1,110 @@
+# resilient-test
+
+Testing utilities for the `kmp-resilient` library, providing fault injection and simplified policy builders for unit tests.
+
+## Features
+
+- **FaultInjector**: Simulate failures, delays, and intermittent behavior
+- **PolicyBuilders**: Pre-configured resilience policies with sensible test defaults
+- **TestResilientScope**: Factory for creating test-friendly scopes
+
+## Installation
+
+Add to your test dependencies:
+
+```kotlin
+kotlin {
+    sourceSets {
+        commonTest.dependencies {
+            implementation("io.github.santimattius.resilient:resilient-test:1.3.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.9.0")
+        }
+    }
+}
+```
+
+## Usage
+
+### Fault Injection
+
+```kotlin
+import com.santimattius.resilient.test.FaultInjector
+import kotlin.time.Duration.Companion.milliseconds
+
+@Test
+fun `test with fault injection`() = runTest {
+    val injector = FaultInjector.builder()
+        .failureRate(0.3)           // 30% failure rate
+        .delay(50.milliseconds)      // 50ms delay
+        .delayJitter(true)           // ±20% jitter
+        .exception { CustomException() }
+        .build()
+
+    val result = injector.execute {
+        fetchData() // may fail or delay
+    }
+}
+```
+
+### Policy Builders
+
+```kotlin
+import com.santimattius.resilient.test.PolicyBuilders
+import com.santimattius.resilient.test.TestResilientScope
+
+@Test
+fun `test retry with fast defaults`() = runTest {
+    val scope = TestResilientScope()
+    val policy = PolicyBuilders.retryPolicy(
+        scope,
+        maxAttempts = 3,
+        initialDelay = 10.milliseconds
+    )
+    
+    var attempts = 0
+    val result = policy.execute {
+        attempts++
+        if (attempts < 3) throw RuntimeException("fail")
+        "success"
+    }
+    
+    assertEquals("success", result)
+    assertEquals(3, attempts)
+}
+```
+
+### Integration Testing
+
+Combine fault injection with resilience policies:
+
+```kotlin
+@Test
+fun `test retry with intermittent failures`() = runTest {
+    val scope = TestResilientScope()
+    val policy = PolicyBuilders.retryPolicy(scope, maxAttempts = 5)
+    
+    val injector = FaultInjector.builder()
+        .failureRate(0.6) // 60% failure rate
+        .build()
+    
+    val result = policy.execute {
+        injector.execute { "success" }
+    }
+    
+    assertEquals("success", result)
+}
+```
+
+## Available Policy Builders
+
+- `retryPolicy(scope, maxAttempts, initialDelay, maxDelay, shouldRetry)`
+- `timeoutPolicy(scope, timeout)`
+- `circuitBreakerPolicy(scope, failureThreshold, successThreshold, timeout)`
+- `bulkheadPolicy(scope, maxConcurrentCalls, maxWaitingCalls)`
+- `rateLimiterPolicy(scope, maxCalls, period)`
+
+All builders use fast defaults optimized for testing (short delays, small thresholds).
+
+## License
+
+Apache 2.0

--- a/resilient-test/build.gradle.kts
+++ b/resilient-test/build.gradle.kts
@@ -12,7 +12,7 @@ version = "1.3.0"
 
 kotlin {
     androidLibrary {
-        namespace = "io.github.santimattius.resilient"
+        namespace = "io.github.santimattius.resilient.test"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -38,7 +38,6 @@ kotlin {
         nodejs()
     }
 
-    // Native targets - Tier 1 only
     macosArm64()
 
     listOf(
@@ -47,21 +46,19 @@ kotlin {
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
-            baseName = "Resilient"
+            baseName = "ResilientTest"
             isStatic = true
         }
     }
 
     sourceSets {
         commonMain.dependencies {
-            // put your Multiplatform dependencies here
             implementation(libs.kotlinx.coroutines.core)
-            implementation(libs.kotlinx.datetime)
+            api(project(":shared"))
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutines.test)
-            implementation(libs.turbine)
         }
         val jvmTest by getting {
             dependencies {
@@ -72,5 +69,5 @@ kotlin {
     }
 }
 
-extra["resilientMavenArtifactId"] = "resilient"
+extra["resilientMavenArtifactId"] = "resilient-test"
 apply(from = rootProject.file("gradle/resilient-maven-publishing.gradle"))

--- a/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/FaultInjector.kt
+++ b/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/FaultInjector.kt
@@ -1,0 +1,118 @@
+package com.santimattius.resilient.test
+
+import kotlinx.coroutines.delay
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Fault injection helper for testing resilience policies.
+ *
+ * Use this in tests to inject artificial delays, failures, or intermittent behavior
+ * to validate that your policies (retry, circuit breaker, timeout, etc.) handle them correctly.
+ *
+ * **Example:**
+ * ```kotlin
+ * val injector = FaultInjector.builder()
+ *     .failureRate(0.3)
+ *     .delay(50.milliseconds)
+ *     .build()
+ *
+ * val result = injector.execute {
+ *     fetchData() // may throw or delay
+ * }
+ * ```
+ *
+ * @property failureRate Probability of throwing [exception] on each call (0.0 = never, 1.0 = always).
+ * @property exception The exception to throw when a failure is injected.
+ * @property delay Fixed delay added before executing [block] (simulates slow network/DB).
+ * @property delayJitter If `true`, actual delay is randomized ±20% around [delay].
+ */
+class FaultInjector(
+    private val failureRate: Double = 0.0,
+    private val exception: () -> Throwable = { FaultInjectedException() },
+    private val delay: Duration = Duration.ZERO,
+    private val delayJitter: Boolean = false
+) {
+    init {
+        require(failureRate in 0.0..1.0) {
+            "failureRate must be in [0.0, 1.0], got $failureRate"
+        }
+    }
+
+    /**
+     * Executes [block], potentially injecting a delay and/or failure according to configuration.
+     *
+     * @param T The return type of [block].
+     * @param block The suspendable operation to execute (may be wrapped with injected faults).
+     * @return The result of [block] if no failure is injected.
+     * @throws Throwable The configured [exception] if a failure is injected, or any exception from [block].
+     */
+    suspend fun <T> execute(block: suspend () -> T): T {
+        if (delay.isPositive()) {
+            val actualDelay = if (delayJitter) {
+                (delay.inWholeMilliseconds * (0.8 + Random.nextDouble(0.4))).toLong().milliseconds
+            } else {
+                delay
+            }
+            delay(actualDelay)
+        }
+
+        if (failureRate > 0.0 && Random.nextDouble() < failureRate) {
+            throw exception()
+        }
+
+        return block()
+    }
+
+    companion object {
+        /**
+         * Returns a builder for configuring a [FaultInjector].
+         */
+        fun builder(): Builder = Builder()
+    }
+
+    /**
+     * Builder for [FaultInjector].
+     */
+    class Builder {
+        private var failureRate: Double = 0.0
+        private var exception: () -> Throwable = { FaultInjectedException() }
+        private var delay: Duration = Duration.ZERO
+        private var delayJitter: Boolean = false
+
+        /**
+         * Sets the probability of throwing an exception on each call.
+         * @param rate Value in [0.0, 1.0]. Default is 0.0 (no failures).
+         */
+        fun failureRate(rate: Double) = apply { this.failureRate = rate }
+
+        /**
+         * Sets the exception factory to use when a failure is injected.
+         * @param block Lambda that produces the exception to throw.
+         */
+        fun exception(block: () -> Throwable) = apply { this.exception = block }
+
+        /**
+         * Sets a fixed delay added before executing the block.
+         * @param duration The delay duration. Default is [Duration.ZERO].
+         */
+        fun delay(duration: Duration) = apply { this.delay = duration }
+
+        /**
+         * Enables or disables jitter on the delay (±20% randomization).
+         * @param enable `true` to add jitter, `false` for fixed delay. Default is `false`.
+         */
+        fun delayJitter(enable: Boolean) = apply { this.delayJitter = enable }
+
+        /**
+         * Builds the [FaultInjector] with the configured settings.
+         */
+        fun build(): FaultInjector = FaultInjector(failureRate, exception, delay, delayJitter)
+    }
+}
+
+/**
+ * Exception thrown by [FaultInjector] when a failure is injected.
+ */
+class FaultInjectedException(message: String = "Fault injected by FaultInjector") : Exception(message)

--- a/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/PolicyBuilders.kt
+++ b/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/PolicyBuilders.kt
@@ -1,0 +1,142 @@
+package com.santimattius.resilient.test
+
+import com.santimattius.resilient.ResilientPolicy
+import com.santimattius.resilient.composition.ResilientScope
+import com.santimattius.resilient.composition.resilient
+import com.santimattius.resilient.retry.ExponentialBackoff
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Convenience builders for creating [ResilientPolicy] instances with common test configurations.
+ *
+ * These builders reduce boilerplate in tests by providing sensible defaults for resilience policies.
+ */
+object PolicyBuilders {
+
+    /**
+     * Creates a [ResilientPolicy] with a retry policy configured for fast testing.
+     *
+     * **Default configuration:**
+     * - `maxAttempts = 3`
+     * - `backoffStrategy = ExponentialBackoff(initialDelay = 10ms, maxDelay = 100ms, factor = 2.0)`
+     * - `shouldRetry = { true }` (retries all exceptions)
+     *
+     * @param scope The [ResilientScope] for the policy (typically a [TestResilientScope]).
+     * @param maxAttempts Maximum number of retry attempts. Default is 3.
+     * @param initialDelay Initial backoff delay. Default is 10ms.
+     * @param maxDelay Maximum backoff delay. Default is 100ms.
+     * @param shouldRetry Predicate to determine if an exception should trigger a retry. Default retries all.
+     * @return A configured [ResilientPolicy] with retry.
+     */
+    fun retryPolicy(
+        scope: ResilientScope,
+        maxAttempts: Int = 3,
+        initialDelay: Duration = 10.milliseconds,
+        maxDelay: Duration = 100.milliseconds,
+        shouldRetry: (Throwable) -> Boolean = { true }
+    ): ResilientPolicy = resilient(scope) {
+        retry {
+            this.maxAttempts = maxAttempts
+            this.shouldRetry = shouldRetry
+            this.backoffStrategy = ExponentialBackoff(
+                initialDelay = initialDelay,
+                maxDelay = maxDelay,
+                factor = 2.0
+            )
+        }
+    }
+
+    /**
+     * Creates a [ResilientPolicy] with a timeout policy configured for fast testing.
+     *
+     * **Default configuration:**
+     * - `timeout = 1.second`
+     *
+     * @param scope The [ResilientScope] for the policy.
+     * @param timeout The timeout duration. Default is 1 second.
+     * @return A configured [ResilientPolicy] with timeout.
+     */
+    fun timeoutPolicy(
+        scope: ResilientScope,
+        timeout: Duration = 1.seconds
+    ): ResilientPolicy = resilient(scope) {
+        timeout { this.timeout = timeout }
+    }
+
+    /**
+     * Creates a [ResilientPolicy] with a circuit breaker configured for fast testing.
+     *
+     * **Default configuration:**
+     * - `failureThreshold = 3`
+     * - `successThreshold = 2`
+     * - `halfOpenMaxCalls = 1`
+     * - `timeout = 5.seconds`
+     *
+     * @param scope The [ResilientScope] for the policy.
+     * @param failureThreshold Number of failures to open the circuit. Default is 3.
+     * @param successThreshold Number of successes to close the circuit from half-open. Default is 2.
+     * @param timeout Duration the circuit stays open. Default is 5 seconds.
+     * @return A configured [ResilientPolicy] with circuit breaker.
+     */
+    fun circuitBreakerPolicy(
+        scope: ResilientScope,
+        failureThreshold: Int = 3,
+        successThreshold: Int = 2,
+        timeout: Duration = 5.seconds
+    ): ResilientPolicy = resilient(scope) {
+        circuitBreaker {
+            this.failureThreshold = failureThreshold
+            this.successThreshold = successThreshold
+            this.halfOpenMaxCalls = 1
+            this.timeout = timeout
+        }
+    }
+
+    /**
+     * Creates a [ResilientPolicy] with a bulkhead configured for fast testing.
+     *
+     * **Default configuration:**
+     * - `maxConcurrentCalls = 2`
+     * - `maxWaitingCalls = 4`
+     *
+     * @param scope The [ResilientScope] for the policy.
+     * @param maxConcurrentCalls Maximum number of concurrent executions. Default is 2.
+     * @param maxWaitingCalls Maximum number of waiting calls. Default is 4.
+     * @return A configured [ResilientPolicy] with bulkhead.
+     */
+    fun bulkheadPolicy(
+        scope: ResilientScope,
+        maxConcurrentCalls: Int = 2,
+        maxWaitingCalls: Int = 4
+    ): ResilientPolicy = resilient(scope) {
+        bulkhead {
+            this.maxConcurrentCalls = maxConcurrentCalls
+            this.maxWaitingCalls = maxWaitingCalls
+        }
+    }
+
+    /**
+     * Creates a [ResilientPolicy] with a rate limiter configured for fast testing.
+     *
+     * **Default configuration:**
+     * - `maxCalls = 5`
+     * - `period = 1.second`
+     *
+     * @param scope The [ResilientScope] for the policy.
+     * @param maxCalls Maximum number of calls allowed in the period. Default is 5.
+     * @param period Time period for rate limiting. Default is 1 second.
+     * @return A configured [ResilientPolicy] with rate limiter.
+     */
+    fun rateLimiterPolicy(
+        scope: ResilientScope,
+        maxCalls: Int = 5,
+        period: Duration = 1.seconds
+    ): ResilientPolicy = resilient(scope) {
+        rateLimiter {
+            this.maxCalls = maxCalls
+            this.period = period
+        }
+    }
+}

--- a/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/TestResilientScope.kt
+++ b/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/TestResilientScope.kt
@@ -1,0 +1,31 @@
+package com.santimattius.resilient.test
+
+import com.santimattius.resilient.composition.ResilientScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+/**
+ * A [ResilientScope] factory for testing.
+ *
+ * Use this in unit tests to create resilient policies without needing a real application scope.
+ * The returned [ResilientScope] can be closed to cancel all policies and operations.
+ *
+ * **Example:**
+ * ```kotlin
+ * @Test
+ * fun `test retry policy`() = runTest {
+ *     val testScope = TestResilientScope()
+ *     val policy = resilient(testScope) {
+ *         retry { maxAttempts = 3 }
+ *     }
+ *     // ... test logic
+ *     testScope.close() // cleanup
+ * }
+ * ```
+ *
+ * @param dispatcher The [CoroutineDispatcher] for the scope. Defaults to [Dispatchers.Default].
+ * @return A [ResilientScope] instance for testing.
+ */
+fun TestResilientScope(dispatcher: CoroutineDispatcher = Dispatchers.Default): ResilientScope {
+    return ResilientScope(dispatcher)
+}

--- a/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/FaultInjectorTest.kt
+++ b/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/FaultInjectorTest.kt
@@ -1,0 +1,86 @@
+package com.santimattius.resilient.test
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+class FaultInjectorTest {
+
+    @Test
+    fun `given no faults when execute then block succeeds`() = runTest {
+        val injector = FaultInjector.builder().build()
+        val result = injector.execute { "success" }
+        assertEquals("success", result)
+    }
+
+    @Test
+    fun `given failureRate 1_0 when execute then always throws`() = runTest {
+        val injector = FaultInjector.builder()
+            .failureRate(1.0)
+            .build()
+
+        assertFailsWith<FaultInjectedException> {
+            injector.execute { "should not return" }
+        }
+    }
+
+    @Test
+    fun `given custom exception when failure injected then throws custom exception`() = runTest {
+        class CustomException : Exception("custom")
+        val injector = FaultInjector.builder()
+            .failureRate(1.0)
+            .exception { CustomException() }
+            .build()
+
+        val error = assertFailsWith<CustomException> {
+            injector.execute { "should not return" }
+        }
+        assertEquals("custom", error.message)
+    }
+
+    @Test
+    fun `given delay when execute then adds delay before block`() = runTest {
+        val injector = FaultInjector.builder()
+            .delay(50.milliseconds)
+            .build()
+
+        val start = testScheduler.currentTime
+        injector.execute { "delayed" }
+        val elapsed = testScheduler.currentTime - start
+
+        assertTrue(elapsed >= 50, "Expected delay >= 50ms, got $elapsed ms")
+    }
+
+    @Test
+    fun `given failureRate 0_5 when execute many times then approximately half fail`() = runTest {
+        val injector = FaultInjector.builder()
+            .failureRate(0.5)
+            .build()
+
+        var failures = 0
+        var successes = 0
+        repeat(100) {
+            try {
+                injector.execute { "ok" }
+                successes++
+            } catch (e: FaultInjectedException) {
+                failures++
+            }
+        }
+
+        // With 100 trials and p=0.5, expect roughly 40-60 failures (allow wide margin for randomness)
+        assertTrue(failures in 30..70, "Expected ~50 failures, got $failures")
+        assertTrue(successes in 30..70, "Expected ~50 successes, got $successes")
+    }
+
+    @Test
+    fun `given invalid failureRate when build then throws`() {
+        val error = assertFailsWith<IllegalArgumentException> {
+            FaultInjector.builder().failureRate(1.5).build()
+        }
+        assertTrue(error.message!!.contains("failureRate must be in"))
+    }
+}

--- a/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/IntegrationTest.kt
+++ b/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/IntegrationTest.kt
@@ -1,0 +1,140 @@
+package com.santimattius.resilient.test
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Integration tests demonstrating how to use [FaultInjector] with resilience policies.
+ */
+class IntegrationTest {
+
+    @Test
+    fun `given retry policy with fault injector when intermittent failures then eventually succeeds`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.retryPolicy(
+            scope,
+            maxAttempts = 5,
+            initialDelay = 10.milliseconds
+        )
+
+        val injector = FaultInjector.builder()
+            .failureRate(0.6) // 60% failure rate
+            .build()
+
+        var attempts = 0
+        val result = policy.execute {
+            attempts++
+            injector.execute {
+                "success after retries"
+            }
+        }
+
+        assertEquals("success after retries", result)
+        assertTrue(attempts >= 1, "Expected at least 1 attempt")
+    }
+
+    @Test
+    fun `given circuit breaker with fault injector when high failure rate then opens circuit`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.circuitBreakerPolicy(
+            scope,
+            failureThreshold = 3,
+            timeout = 1000.milliseconds
+        )
+
+        val injector = FaultInjector.builder()
+            .failureRate(1.0) // Always fails
+            .exception { RuntimeException("injected failure") }
+            .build()
+
+        // Fail 3 times to open circuit
+        var failures = 0
+        repeat(3) {
+            try {
+                policy.execute {
+                    injector.execute { "should fail" }
+                }
+            } catch (e: RuntimeException) {
+                failures++
+            }
+        }
+
+        assertEquals(3, failures, "Expected 3 failures to open circuit")
+
+        // Fourth call should be rejected by open circuit (not by injector)
+        val fourthResult = runCatching {
+            policy.execute {
+                injector.execute { "should be rejected by circuit" }
+            }
+        }
+
+        // Circuit breaker should reject the call
+        assertTrue(fourthResult.isFailure, "Expected circuit breaker to reject the call")
+    }
+
+    @Test
+    fun `given timeout policy with slow fault injector when delay exceeds timeout then times out`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.timeoutPolicy(scope, timeout = 50.milliseconds)
+
+        val injector = FaultInjector.builder()
+            .delay(100.milliseconds)
+            .build()
+
+        try {
+            policy.execute {
+                injector.execute { "should timeout" }
+            }
+        } catch (e: kotlinx.coroutines.TimeoutCancellationException) {
+            // Expected timeout
+        }
+    }
+
+    @Test
+    fun `given bulkhead with fault injector when slow operations then limits concurrency`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.bulkheadPolicy(
+            scope,
+            maxConcurrentCalls = 2,
+            maxWaitingCalls = 1
+        )
+
+        val injector = FaultInjector.builder()
+            .delay(100.milliseconds)
+            .build()
+
+        val gate = CompletableDeferred<Unit>()
+        val results = mutableListOf<Result<String>>()
+
+        // Launch 4 concurrent calls
+        val jobs = List(4) { index ->
+            launch {
+                results.add(
+                    runCatching {
+                        policy.execute {
+                            injector.execute {
+                                gate.await()
+                                "result-$index"
+                            }
+                        }
+                    }
+                )
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        // Release gate
+        gate.complete(Unit)
+        jobs.forEach { it.join() }
+
+        // At least one call should have been rejected by bulkhead
+        val rejections = results.count { it.isFailure }
+        assertTrue(rejections >= 1, "Expected at least 1 rejection, got $rejections")
+    }
+}

--- a/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/PolicyBuildersTest.kt
+++ b/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/PolicyBuildersTest.kt
@@ -1,0 +1,110 @@
+package com.santimattius.resilient.test
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+
+class PolicyBuildersTest {
+
+    @Test
+    fun `given retryPolicy when block fails then retries`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.retryPolicy(scope, maxAttempts = 3)
+
+        var attempts = 0
+        val result = policy.execute {
+            attempts++
+            if (attempts < 3) throw RuntimeException("fail")
+            "success"
+        }
+
+        assertEquals("success", result)
+        assertEquals(3, attempts)
+    }
+
+    @Test
+    fun `given timeoutPolicy when block exceeds timeout then throws`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.timeoutPolicy(scope, timeout = 100.milliseconds)
+
+        assertFailsWith<kotlinx.coroutines.TimeoutCancellationException> {
+            policy.execute {
+                kotlinx.coroutines.delay(200)
+                "should timeout"
+            }
+        }
+    }
+
+    @Test
+    fun `given circuitBreakerPolicy when failures exceed threshold then opens circuit`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.circuitBreakerPolicy(
+            scope,
+            failureThreshold = 2,
+            timeout = 1000.milliseconds
+        )
+
+        // Fail twice to open circuit
+        repeat(2) {
+            assertFailsWith<RuntimeException> {
+                policy.execute { throw RuntimeException("fail") }
+            }
+        }
+
+        // Third call should be rejected by open circuit
+        assertFailsWith<Exception> {
+            policy.execute { "should be rejected" }
+        }
+    }
+
+    @Test
+    fun `given bulkheadPolicy when concurrent calls exceed limit then rejects`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.bulkheadPolicy(
+            scope,
+            maxConcurrentCalls = 1,
+            maxWaitingCalls = 0
+        )
+
+        val gate = CompletableDeferred<Unit>()
+        val job1 = launch {
+            policy.execute {
+                gate.await()
+                "first"
+            }
+        }
+
+        testScheduler.advanceUntilIdle()
+
+        // Second call should be rejected
+        assertFailsWith<Exception> {
+            policy.execute { "should be rejected" }
+        }
+
+        gate.complete(Unit)
+        job1.join()
+    }
+
+    @Test
+    fun `given rateLimiterPolicy when calls exceed maxCalls then rejects`() = runTest {
+        val scope = TestResilientScope()
+        val policy = PolicyBuilders.rateLimiterPolicy(
+            scope,
+            maxCalls = 2,
+            period = 1000.milliseconds
+        )
+
+        // First two calls succeed
+        policy.execute { "first" }
+        policy.execute { "second" }
+
+        // Third call should be rejected
+        assertFailsWith<Exception> {
+            policy.execute { "should be rejected" }
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,3 +30,4 @@ dependencyResolutionManagement {
 
 include(":androidApp")
 include(":shared")
+include(":resilient-test")


### PR DESCRIPTION
Introduce a new resilient-test module providing FaultInjector, PolicyBuilders, TestResilientScope, tests, build script and a README with usage examples for testing resilience policies. Add a shared Gradle script (resilient-maven-publishing.gradle) to centralize Maven Central publishing, signing and POM metadata (requires ext.resilientMavenArtifactId). Bump Compose/AndroidX dependency versions in libs.versions.toml and apply small build/settings updates. Also update the project README to document the resilient-test usage and include the generated kotlin-js-store yarn.lock.