### PR TITLE
Upgrade Gradle, AGP, Kotlin and build configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ captures
 !*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
+kotlin-js-store/yarn.lock

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,15 @@ POM_LICENSE_DIST=repo
 POM_DEVELOPER_ID=santimattius
 POM_DEVELOPER_NAME=Santiago Mattiauda
 POM_DEVELOPER_URL=https://github.com/santimattius
+
+#AGP9 Update
+android.defaults.buildfeatures.resvalues=true
+android.sdk.defaultTargetSdkToCompileSdkIfUnset=false
+android.enableAppCompileTimeRClass=false
+android.usesSdkInManifest.disallowed=false
+android.uniquePackageNames=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,12 @@
 [versions]
-agp = "8.13.2"
-kotlin = "2.3.10"
+agp = "9.1.0"
+kotlin = "2.3.20"
 mavenPublish = "0.36.0"
 android-compileSdk = "36"
 android-minSdk = "24"
 android-targetSdk = "36"
 
-composeBom = "2026.03.00"
+composeBom = "2026.03.01"
 androidx-lifecycle = "2.10.0"
 
 androidx-activity = "1.13.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/resilient-test/build.gradle.kts
+++ b/resilient-test/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "io.github.santimattius.resilient.test"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 kotlin {
-    androidLibrary {
+    android {
         namespace = "io.github.santimattius.resilient"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()


### PR DESCRIPTION
Bump tooling and platform versions and adjust module build setup: update Gradle wrapper to 9.3.1, AGP to 9.1.0, Kotlin to 2.3.20 and Compose BOM to 2026.03.01. Add several Android/AGP-related flags to gradle.properties to accommodate AGP9 behavior and R8 settings. Switch kotlin { androidLibrary { ... } } to kotlin { android { ... } } in resilient-test and shared modules to match updated Kotlin Multiplatform/Android DSL. Add kotlin-js-store/yarn.lock to .gitignore.