### PR TITLE
feat: add DecorrelatedJitterBackoff strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 ## [Unreleased]
 
+### Added
+
+- **Retry — DecorrelatedJitterBackoff**
+  - New `DecorrelatedJitterBackoff(base: Duration, cap: Duration)` backoff strategy implementing `BackoffStrategy`.
+  - Uses a stateless approximation of the AWS decorrelated jitter formula: `min(cap, random(base, base * 3^(attempt-1)))`, safe for use across concurrent `execute()` calls on shared policy instances.
+  - Enforces `base > Duration.ZERO` and `cap >= base` at construction time; violating either throws `IllegalArgumentException`.
+  - Available in `commonMain` with no platform-specific dependencies.
+
 ## [1.4.0] - 2026-03-22
 
 ### Added

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/retry/DefaultRetryPolicy.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/retry/DefaultRetryPolicy.kt
@@ -132,6 +132,51 @@ class FixedBackoff(
     }
 }
 
+/**
+ * A stateless implementation of the AWS decorrelated jitter backoff strategy.
+ *
+ * The delay for each attempt is computed as:
+ * `min(cap, random(base, base * 3^(attempt-1)))`
+ *
+ * This formula approximates the AWS decorrelated jitter pattern without requiring
+ * mutable per-instance state, making it safe to share across concurrent executions.
+ *
+ * @property base The minimum possible delay. Must be positive.
+ * @property cap The maximum possible delay. Must be >= [base].
+ * @throws IllegalArgumentException if [base] is not positive or if [cap] < [base].
+ */
+class DecorrelatedJitterBackoff(
+    val base: Duration,
+    val cap: Duration,
+) : BackoffStrategy {
+
+    init {
+        require(base > Duration.ZERO) { "base must be positive, got $base" }
+        require(cap >= base) { "cap must be >= base, but cap=$cap < base=$base" }
+    }
+
+    /**
+     * Computes the delay in milliseconds for the given [attempt] (1-based).
+     * The result is always in the range [[base], [cap]].
+     * Exposed as an internal function to allow unit-testing the pure calculation.
+     */
+    internal fun computeDelayMs(attempt: Int): Long {
+        val baseMs = base.inWholeMilliseconds
+        val capMs = cap.inWholeMilliseconds
+        val upperBound = (baseMs * JITTER_MULTIPLIER.powSafe(attempt - 1)).toLong().coerceIn(baseMs, capMs)
+        return if (baseMs >= upperBound) baseMs else Random.nextLong(baseMs, upperBound + 1)
+    }
+
+    private companion object {
+        /** AWS decorrelated-jitter multiplier: upper bound grows as 3^(attempt-1). */
+        const val JITTER_MULTIPLIER = 3.0
+    }
+
+    override suspend fun delay(attempt: Int) {
+        delay(computeDelayMs(attempt).milliseconds)
+    }
+}
+
 private fun Double.powSafe(exp: Int): Double {
     var result = 1.0
     repeat(exp.coerceAtLeast(0)) { result *= this }

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/retry/DecorrelatedJitterBackoffTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/retry/DecorrelatedJitterBackoffTest.kt
@@ -1,0 +1,102 @@
+package com.santimattius.resilient.retry
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class DecorrelatedJitterBackoffTest {
+
+    // ── Scenario 1: every delay is in [base, cap] ────────────────────────────
+
+    @Test
+    fun `given base 100ms and cap 2s when computeDelayMs called for attempts 1 to 10 then all values are in range`() =
+        runTest {
+            val backoff = DecorrelatedJitterBackoff(base = 100.milliseconds, cap = 2.seconds)
+
+            repeat(10) { index ->
+                val attempt = index + 1
+                val delayMs = backoff.computeDelayMs(attempt)
+                assertTrue(delayMs >= 100L, "attempt $attempt: delay $delayMs < base 100ms")
+                assertTrue(delayMs <= 2000L, "attempt $attempt: delay $delayMs > cap 2000ms")
+            }
+        }
+
+    @Test
+    fun `given base 50ms and cap 500ms when computeDelayMs called for attempts 1 to 20 then all values are in range`() =
+        runTest {
+            // Triangulation: different base/cap values still respect the range
+            val backoff = DecorrelatedJitterBackoff(base = 50.milliseconds, cap = 500.milliseconds)
+
+            repeat(20) { index ->
+                val attempt = index + 1
+                val delayMs = backoff.computeDelayMs(attempt)
+                assertTrue(delayMs >= 50L, "attempt $attempt: delay $delayMs < base 50ms")
+                assertTrue(delayMs <= 500L, "attempt $attempt: delay $delayMs > cap 500ms")
+            }
+        }
+
+    // ── Scenario 2: invalid base/cap throws ──────────────────────────────────
+
+    @Test
+    fun `given cap less than base when constructed then throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            DecorrelatedJitterBackoff(base = 500.milliseconds, cap = 200.milliseconds)
+        }
+    }
+
+    @Test
+    fun `given zero base when constructed then throws IllegalArgumentException`() {
+        assertFailsWith<IllegalArgumentException> {
+            DecorrelatedJitterBackoff(base = 0.milliseconds, cap = 1.seconds)
+        }
+    }
+
+    // ── Scenario 3: used inside a retry policy ───────────────────────────────
+
+    @Test
+    fun `given retry policy with decorrelated jitter when block fails every attempt then retries 3 times and rethrows`() =
+        runTest {
+            val backoff = DecorrelatedJitterBackoff(base = 50.milliseconds, cap = 1.seconds)
+            val cfg = RetryPolicyConfig().apply {
+                maxAttempts = 4
+                backoffStrategy = backoff
+            }
+            val policy = DefaultRetryPolicy(cfg)
+            var attempts = 0
+            val targetException = RuntimeException("always fails")
+
+            val thrown = assertFailsWith<RuntimeException> {
+                policy.execute {
+                    attempts++
+                    throw targetException
+                }
+            }
+
+            assertTrue(attempts == 4, "Expected 4 attempts (1 initial + 3 retries), got $attempts")
+            assertTrue(thrown === targetException, "Should rethrow the last exception instance")
+        }
+
+    @Test
+    fun `given retry policy with decorrelated jitter when block eventually succeeds then returns result`() =
+        runTest {
+            // Triangulation for Scenario 3: success path
+            val backoff = DecorrelatedJitterBackoff(base = 50.milliseconds, cap = 1.seconds)
+            val cfg = RetryPolicyConfig().apply {
+                maxAttempts = 4
+                backoffStrategy = backoff
+            }
+            val policy = DefaultRetryPolicy(cfg)
+            var attempts = 0
+
+            val result = policy.execute {
+                attempts++
+                if (attempts < 3) throw RuntimeException("fail") else "success"
+            }
+
+            assertTrue(attempts == 3, "Expected 3 attempts, got $attempts")
+            assertTrue(result == "success")
+        }
+}


### PR DESCRIPTION
## Description

Adds AWS decorrelated jitter backoff strategy for retry policies. Breaks correlated retry storms without mutable shared state.