### PR TITLE
feat: add RateLimiterRegistry for per-key/per-tenant rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 ## [Unreleased]
 
+### Added
+
+- **RateLimiterRegistry**
+  - `RateLimiterRegistry` for named, shared rate-limiter instances so multiple policies can share the same token-bucket quota (e.g. all `"payments"` calls consume from the same pool).
+  - `getOrCreate(name, configure, onRateLimited?)` follows a first-name-wins contract: the first call for a given name creates the limiter; subsequent calls return the same instance and ignore the configure block. Not synchronized across threads (startup-time construct, matching `BulkheadRegistry` contract).
+  - `ResilientBuilder.rateLimiterNamed(registry, name, configure)` DSL — mutually exclusive with `rateLimiter { }`. Throws `IllegalArgumentException` at build time if both are configured.
+
 ## [1.4.0] - 2026-03-22
 
 ### Added

--- a/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/FaultInjector.kt
+++ b/resilient-test/src/commonMain/kotlin/com/santimattius/resilient/test/FaultInjector.kt
@@ -11,34 +11,49 @@ import kotlin.time.Duration.Companion.milliseconds
  * Use this in tests to inject artificial delays, failures, or intermittent behavior
  * to validate that your policies (retry, circuit breaker, timeout, etc.) handle them correctly.
  *
- * **Example:**
+ * Prefer [failCount] over [failureRate] for deterministic tests — [failureRate] introduces
+ * randomness that can cause intermittent test failures.
+ *
+ * **Example — deterministic (preferred):**
+ * ```kotlin
+ * val injector = FaultInjector.builder()
+ *     .failCount(3) // fails first 3 calls, succeeds after
+ *     .build()
+ * ```
+ *
+ * **Example — probabilistic:**
  * ```kotlin
  * val injector = FaultInjector.builder()
  *     .failureRate(0.3)
  *     .delay(50.milliseconds)
  *     .build()
- *
- * val result = injector.execute {
- *     fetchData() // may throw or delay
- * }
  * ```
  *
  * @property failureRate Probability of throwing [exception] on each call (0.0 = never, 1.0 = always).
+ *   Ignored when [failCount] > 0.
  * @property exception The exception to throw when a failure is injected.
  * @property delay Fixed delay added before executing [block] (simulates slow network/DB).
  * @property delayJitter If `true`, actual delay is randomized ±20% around [delay].
+ * @property failCount Number of calls that will deterministically throw before succeeding.
+ *   When > 0, takes precedence over [failureRate].
  */
 class FaultInjector(
     private val failureRate: Double = 0.0,
     private val exception: () -> Throwable = { FaultInjectedException() },
     private val delay: Duration = Duration.ZERO,
-    private val delayJitter: Boolean = false
+    private val delayJitter: Boolean = false,
+    failCount: Int = 0
 ) {
     init {
         require(failureRate in 0.0..1.0) {
             "failureRate must be in [0.0, 1.0], got $failureRate"
         }
+        require(failCount >= 0) {
+            "failCount must be >= 0, got $failCount"
+        }
     }
+
+    private var remainingFailures: Int = failCount
 
     /**
      * Executes [block], potentially injecting a delay and/or failure according to configuration.
@@ -56,6 +71,11 @@ class FaultInjector(
                 delay
             }
             delay(actualDelay)
+        }
+
+        if (remainingFailures > 0) {
+            remainingFailures--
+            throw exception()
         }
 
         if (failureRate > 0.0 && Random.nextDouble() < failureRate) {
@@ -80,9 +100,18 @@ class FaultInjector(
         private var exception: () -> Throwable = { FaultInjectedException() }
         private var delay: Duration = Duration.ZERO
         private var delayJitter: Boolean = false
+        private var failCount: Int = 0
+
+        /**
+         * Sets a deterministic failure count: the first [count] calls will throw, then succeed.
+         * Takes precedence over [failureRate] when > 0. Preferred over [failureRate] for tests.
+         * @param count Number of calls that will throw before succeeding. Must be >= 0.
+         */
+        fun failCount(count: Int) = apply { this.failCount = count }
 
         /**
          * Sets the probability of throwing an exception on each call.
+         * Prefer [failCount] for deterministic tests.
          * @param rate Value in [0.0, 1.0]. Default is 0.0 (no failures).
          */
         fun failureRate(rate: Double) = apply { this.failureRate = rate }
@@ -108,7 +137,7 @@ class FaultInjector(
         /**
          * Builds the [FaultInjector] with the configured settings.
          */
-        fun build(): FaultInjector = FaultInjector(failureRate, exception, delay, delayJitter)
+        fun build(): FaultInjector = FaultInjector(failureRate, exception, delay, delayJitter, failCount)
     }
 }
 

--- a/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/IntegrationTest.kt
+++ b/resilient-test/src/commonTest/kotlin/com/santimattius/resilient/test/IntegrationTest.kt
@@ -23,7 +23,7 @@ class IntegrationTest {
         )
 
         val injector = FaultInjector.builder()
-            .failureRate(0.6) // 60% failure rate
+            .failCount(3) // fail first 3 calls, succeed on 4th
             .build()
 
         var attempts = 0
@@ -35,7 +35,7 @@ class IntegrationTest {
         }
 
         assertEquals("success after retries", result)
-        assertTrue(attempts >= 1, "Expected at least 1 attempt")
+        assertEquals(4, attempts, "Expected exactly 4 attempts (3 failures + 1 success)")
     }
 
     @Test

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
@@ -18,6 +18,7 @@ import com.santimattius.resilient.hedging.DefaultHedgingPolicy
 import com.santimattius.resilient.hedging.HedgingConfig
 import com.santimattius.resilient.ratelimiter.DefaultRateLimiter
 import com.santimattius.resilient.ratelimiter.RateLimiterConfig
+import com.santimattius.resilient.ratelimiter.RateLimiterRegistry
 import com.santimattius.resilient.retry.DefaultRetryPolicy
 import com.santimattius.resilient.retry.RetryPolicyConfig
 import com.santimattius.resilient.PolicyHealthSnapshot
@@ -42,6 +43,15 @@ internal data class BulkheadNamedSpec(
     val registry: BulkheadRegistry,
     val name: String,
     val configure: BulkheadConfig.() -> Unit
+)
+
+/**
+ * Named rate-limiter request: resolved at [resilient] build time via [RateLimiterRegistry.getOrCreate].
+ */
+internal data class RateLimiterNamedSpec(
+    val registry: RateLimiterRegistry,
+    val name: String,
+    val configure: RateLimiterConfig.() -> Unit
 )
 
 /**
@@ -83,6 +93,7 @@ class ResilientBuilder {
     internal var retryConfig: RetryPolicyConfig? = null
     internal var circuitBreakerConfig: CircuitBreakerConfig? = null
     internal var rateLimiterConfig: RateLimiterConfig? = null
+    internal var rateLimiterNamedSpec: RateLimiterNamedSpec? = null
     internal var bulkheadConfig: BulkheadConfig? = null
     internal var bulkheadNamedSpec: BulkheadNamedSpec? = null
     internal var timeoutConfig: TimeoutConfig? = null
@@ -114,7 +125,31 @@ class ResilientBuilder {
      * @param config Lambda to configure [RateLimiterConfig] (e.g. maxCalls, period).
      */
     fun rateLimiter(config: RateLimiterConfig.() -> Unit) {
+        require(rateLimiterNamedSpec == null) {
+            "Cannot use rateLimiter { } together with rateLimiterNamed(...); choose one."
+        }
         rateLimiterConfig = (rateLimiterConfig ?: RateLimiterConfig()).apply(config)
+    }
+
+    /**
+     * Uses a shared [DefaultRateLimiter] from [registry] keyed by [name].
+     * Multiple policies can pass the same [RateLimiterRegistry] and name to enforce a **global** quota
+     * across those policies.
+     *
+     * Cannot be combined with [rateLimiter] in the same builder.
+     */
+    fun rateLimiterNamed(
+        registry: RateLimiterRegistry,
+        name: String,
+        configure: RateLimiterConfig.() -> Unit
+    ) {
+        require(rateLimiterConfig == null) {
+            "Cannot use rateLimiterNamed(...) together with rateLimiter { }; choose one."
+        }
+        require(rateLimiterNamedSpec == null) {
+            "rateLimiterNamed(...) can only be configured once per policy."
+        }
+        rateLimiterNamedSpec = RateLimiterNamedSpec(registry, name, configure)
     }
 
     /**
@@ -317,7 +352,11 @@ fun resilient(
         }
     }
 
-    val rateLimiter = builder.rateLimiterConfig?.let { cfg ->
+    val rateLimiter = builder.rateLimiterNamedSpec?.let { spec ->
+        spec.registry.getOrCreate(spec.name, spec.configure) { wait ->
+            events.emit(ResilientEvent.RateLimited(wait))
+        }
+    } ?: builder.rateLimiterConfig?.let { cfg ->
         DefaultRateLimiter(
             config = cfg,
             onRateLimited = { wait ->

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/ratelimiter/RateLimiterRegistry.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/ratelimiter/RateLimiterRegistry.kt
@@ -1,0 +1,41 @@
+package com.santimattius.resilient.ratelimiter
+
+import kotlin.time.Duration
+
+/**
+ * Registry of named [DefaultRateLimiter] instances so multiple [com.santimattius.resilient.ResilientPolicy]
+ * configurations can **share** the same rate-limiter quota (e.g. one token bucket per downstream `"payments"`, `"db"`).
+ *
+ * **Thread-safety:** [getOrCreate] is **not** synchronized across platforms. Typical use is to build policies
+ * on a single thread at startup; do not call [getOrCreate] concurrently for the same registry without external
+ * synchronization.
+ *
+ * The first successful [getOrCreate] for a given [name] wins; subsequent calls return the same instance and
+ * ignore configuration differences (document your convention: one name, one config).
+ */
+class RateLimiterRegistry {
+
+    private val instances = mutableMapOf<String, DefaultRateLimiter>()
+
+    /**
+     * Returns an existing [DefaultRateLimiter] for [name], or creates one with [configure].
+     *
+     * @param name Logical name identifying the shared limiter (e.g. `"payments"`, `"db"`).
+     * @param configure Lambda to configure [RateLimiterConfig] — only applied on first creation.
+     * @param onRateLimited Optional suspendable callback forwarded to [DefaultRateLimiter] **only** when the
+     *   instance is first created. Receives the wait [Duration] before the rate-limited call is allowed or rejected.
+     */
+    fun getOrCreate(
+        name: String,
+        configure: RateLimiterConfig.() -> Unit,
+        onRateLimited: (suspend (Duration) -> Unit)? = null
+    ): DefaultRateLimiter {
+        instances[name]?.let { return it }
+        val created = DefaultRateLimiter(
+            config = RateLimiterConfig().apply(configure),
+            onRateLimited = onRateLimited ?: {}
+        )
+        instances[name] = created
+        return created
+    }
+}

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/ratelimiter/RateLimiterRegistryTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/ratelimiter/RateLimiterRegistryTest.kt
@@ -1,0 +1,194 @@
+package com.santimattius.resilient.ratelimiter
+
+import com.santimattius.resilient.composition.ResilientScope
+import com.santimattius.resilient.composition.resilient
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class RateLimiterRegistryTest {
+
+    // ---------- Scenario 1: First registration creates the limiter ----------
+
+    @Test
+    fun `given empty registry when getOrCreate called then new limiter is created and returned`() {
+        val registry = RateLimiterRegistry()
+
+        val limiter = registry.getOrCreate(
+            name = "payments",
+            configure = {
+                maxCalls = 10
+                period = 1.seconds
+            }
+        )
+
+        assertNotNull(limiter)
+    }
+
+    // Triangulation: a different name creates a different instance
+    @Test
+    fun `given empty registry when getOrCreate called with different names then distinct limiters created`() {
+        val registry = RateLimiterRegistry()
+
+        val paymentsLimiter = registry.getOrCreate("payments", configure = { maxCalls = 10 })
+        val dbLimiter = registry.getOrCreate("db", configure = { maxCalls = 5 })
+
+        assertTrue(paymentsLimiter !== dbLimiter, "Different names must produce distinct instances")
+    }
+
+    // ---------- Scenario 2: Subsequent call returns the same instance ----------
+
+    @Test
+    fun `given existing payments entry when getOrCreate called again then original instance is returned`() {
+        val registry = RateLimiterRegistry()
+
+        val first = registry.getOrCreate("payments", configure = { maxCalls = 10 })
+        val second = registry.getOrCreate("payments", configure = { maxCalls = 999 })
+
+        assertSame(first, second, "First-name-wins: same instance must be returned on second call")
+    }
+
+    // Triangulation: same instance is returned — original config (maxCalls=2) is preserved
+    @Test
+    fun `given existing limiter when getOrCreate called with different maxCalls then original config is preserved`() = runTest {
+        val registry = RateLimiterRegistry()
+
+        registry.getOrCreate("api", configure = {
+            maxCalls = 2
+            period = 1.seconds
+        })
+        // Second call with higher maxCalls — original config (maxCalls=2) wins
+        val limiter = registry.getOrCreate("api", configure = {
+            maxCalls = 100
+            period = 10.seconds
+        })
+
+        // maxCalls=2 is in effect: executing twice should succeed, third must be rejected
+        limiter.execute { "first" }
+        limiter.execute { "second" }
+        assertFailsWith<RateLimitExceededException> {
+            limiter.execute { "third should be rejected" }
+        }
+    }
+
+    // ---------- Scenario 3: Two policies share the same rate-limiter quota ----------
+
+    @Test
+    fun `given two policies with same named limiter when quota exhausted through policy A then policy B is rejected`() = runTest {
+        val registry = RateLimiterRegistry()
+
+        val limiterA = registry.getOrCreate("db", configure = {
+            maxCalls = 5
+            period = 1.seconds
+        })
+        val limiterB = registry.getOrCreate("db", configure = {
+            maxCalls = 5   // ignored — same instance
+            period = 1.seconds
+        })
+
+        // Both must be the exact same instance
+        assertSame(limiterA, limiterB, "Same name must yield same instance for quota sharing")
+
+        // Exhaust 5 calls through limiterA
+        repeat(5) { limiterA.execute { "call" } }
+
+        // Next call through limiterB (== limiterA) must be rejected
+        assertFailsWith<RateLimitExceededException> {
+            limiterB.execute { "should be rejected" }
+        }
+    }
+
+    // ---------- Scenario 4: Combining rateLimiterNamed with rateLimiter throws ----------
+
+    @Test
+    fun `given builder when rateLimiter then rateLimiterNamed called then IllegalArgumentException thrown`() {
+        val registry = RateLimiterRegistry()
+        val scope = ResilientScope()
+
+        assertFailsWith<IllegalArgumentException> {
+            resilient(scope) {
+                rateLimiter { maxCalls = 10 }
+                rateLimiterNamed(registry, "db", configure = { maxCalls = 5 })
+            }
+        }
+    }
+
+    // Triangulation: reversed order — rateLimiterNamed first, then rateLimiter
+    @Test
+    fun `given builder when rateLimiterNamed then rateLimiter called then IllegalArgumentException thrown`() {
+        val registry = RateLimiterRegistry()
+        val scope = ResilientScope()
+
+        assertFailsWith<IllegalArgumentException> {
+            resilient(scope) {
+                rateLimiterNamed(registry, "db", configure = { maxCalls = 5 })
+                rateLimiter { maxCalls = 10 }
+            }
+        }
+    }
+
+    // ---------- Scenario 5: onLimited callback forwarded on rejection ----------
+
+    @Test
+    fun `given registry limiter with onLimited callback when rate limit exceeded then callback invoked`() = runTest {
+        var callbackInvoked = false
+        val registry = RateLimiterRegistry()
+
+        val limiter = registry.getOrCreate(
+            name = "payments",
+            configure = {
+                maxCalls = 1
+                period = 1.seconds
+            },
+            onRateLimited = { _ ->
+                callbackInvoked = true
+            }
+        )
+
+        // Exhaust the quota
+        limiter.execute { "first" }
+
+        // This call exceeds the limit — callback must fire before exception is thrown
+        assertFailsWith<RateLimitExceededException> {
+            limiter.execute { "second" }
+        }
+
+        assertTrue(callbackInvoked, "onLimited callback must be invoked when rate limit is exceeded")
+    }
+
+    // Triangulation: callback receives a positive Duration
+    @Test
+    fun `given registry limiter with onLimited callback when rate limit exceeded then callback receives positive duration`() = runTest {
+        var receivedDuration: kotlin.time.Duration? = null
+        val registry = RateLimiterRegistry()
+
+        val limiter = registry.getOrCreate(
+            name = "api",
+            configure = {
+                maxCalls = 1
+                period = 500.milliseconds
+            },
+            onRateLimited = { wait ->
+                receivedDuration = wait
+            }
+        )
+
+        limiter.execute { "first" }
+
+        assertFailsWith<RateLimitExceededException> {
+            limiter.execute { "second" }
+        }
+
+        val duration = receivedDuration
+        assertNotNull(duration, "Callback must receive the wait Duration")
+        assertTrue(
+            duration > 0.milliseconds,
+            "Callback Duration must be positive, got $duration"
+        )
+    }
+}


### PR DESCRIPTION
## Description
Adds `RateLimiterRegistry` (mirrors `BulkheadRegistry`) for sharing rate limiter quotas across policies by name.