### PR TITLE
feat: add count-based sliding window with failure-rate threshold to CB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 ## [Unreleased]
 
+### Added
+
+- **Circuit Breaker — failure-rate sliding window mode**
+  - `CircuitBreakerConfig.failureRateThreshold: Double?` (0.0–100.0, default `null`): enables count-based failure-rate mode. The circuit opens when the failure rate computed over the last `minimumNumberOfCalls` outcomes meets or exceeds this percentage.
+  - `CircuitBreakerConfig.minimumNumberOfCalls: Int` (default `10`): minimum number of call outcomes that must be recorded before the failure rate is evaluated. Also defines the ring-buffer window size.
+  - Setting both `failureRateThreshold` and `slidingWindow` in the same config throws `IllegalArgumentException`.
+  - Half-open recovery (`successThreshold`) and the existing consecutive-failure and time-based sliding-window modes are unchanged.
+
 ## [1.4.0] - 2026-03-22
 
 ### Added

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreaker.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreaker.kt
@@ -122,6 +122,17 @@ enum class CircuitState {
  * this window are discarded. The circuit opens when at least [failureThreshold] failures fall inside the window.
  * Success in CLOSED only **prunes** expired failures (it does not clear recent failures). [HALF_OPEN][CircuitState.HALF_OPEN]
  * and [OPEN][CircuitState.OPEN] behavior is unchanged.
+ *
+ * @property failureRateThreshold When non-null, enables **failure-rate mode** using a count-based sliding window.
+ * The circuit opens when the failure rate (as a percentage, 0.0–100.0) computed over the last
+ * [minimumNumberOfCalls] outcomes meets or exceeds this value.
+ * The rate is not evaluated until [minimumNumberOfCalls] have been recorded.
+ * Cannot be combined with [slidingWindow]; setting both throws [IllegalArgumentException].
+ * Defaults to `null` (disabled).
+ *
+ * @property minimumNumberOfCalls Minimum number of calls that must be recorded before [failureRateThreshold]
+ * is evaluated. Acts as both the minimum-calls guard and the ring-buffer size. Defaults to `10`.
+ * Only meaningful when [failureRateThreshold] is non-null.
  */
 class CircuitBreakerConfig {
     var failureThreshold: Int = 5
@@ -131,6 +142,8 @@ class CircuitBreakerConfig {
     var shouldRecordFailure: (Throwable) -> Boolean = { true }
     var onStateChange: (CircuitState) -> Unit = { }
     var slidingWindow: Duration? = null
+    var failureRateThreshold: Double? = null
+    var minimumNumberOfCalls: Int = 10
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/DefaultCircuitBreaker.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/DefaultCircuitBreaker.kt
@@ -66,6 +66,13 @@ class DefaultCircuitBreaker(
                 "slidingWindow must be positive when set, got $w"
             }
         }
+        require(config.failureRateThreshold == null || config.slidingWindow == null) {
+            "Cannot combine failureRateThreshold with slidingWindow; choose one trip mode."
+        }
+        val frt = config.failureRateThreshold
+        require(frt == null || frt in 0.0..100.0) {
+            "failureRateThreshold must be in 0.0..100.0, got $frt"
+        }
     }
 
     /** When non-null, CLOSED failures are tracked in a time sliding window (ms). */
@@ -73,6 +80,13 @@ class DefaultCircuitBreaker(
         config.slidingWindow?.takeIf { it.isPositive() }?.inWholeMilliseconds
 
     private val failureTimestamps = ArrayDeque<Long>()
+
+    /**
+     * Ring buffer for failure-rate mode. Each entry is `true` (failure) or `false` (success).
+     * Capped at [CircuitBreakerConfig.minimumNumberOfCalls]; oldest entry evicted when full.
+     * Only populated when [CircuitBreakerConfig.failureRateThreshold] is non-null.
+     */
+    private val ringBuffer = ArrayDeque<Boolean>()
 
     private val mutex = Mutex()
     private val _state = MutableStateFlow(CircuitState.CLOSED)
@@ -267,11 +281,19 @@ class DefaultCircuitBreaker(
         mutex.withLock {
             when (_state.value) {
                 CircuitState.CLOSED -> {
-                    if (slidingWindowMs != null) {
-                        val now = getTimeMillis()
-                        pruneFailureTimestampsLocked(now)
-                    } else {
-                        failureCount = 0
+                    when {
+                        config.failureRateThreshold != null -> {
+                            // Failure-rate mode: record success and evaluate rate (buffer may now be full)
+                            recordOutcomeLocked(failure = false)
+                            evaluateFailureRateLocked()
+                        }
+                        slidingWindowMs != null -> {
+                            val now = getTimeMillis()
+                            pruneFailureTimestampsLocked(now)
+                        }
+                        else -> {
+                            failureCount = 0
+                        }
                     }
                 }
 
@@ -286,6 +308,7 @@ class DefaultCircuitBreaker(
                         successCount = 0
                         failureCount = 0
                         failureTimestamps.clear()
+                        ringBuffer.clear()
                     }
                 }
             }
@@ -298,18 +321,26 @@ class DefaultCircuitBreaker(
         mutex.withLock {
             when (_state.value) {
                 CircuitState.CLOSED -> {
-                    if (slidingWindowMs != null) {
-                        val now = getTimeMillis()
-                        pruneFailureTimestampsLocked(now)
-                        failureTimestamps.addLast(now)
-                        pruneFailureTimestampsLocked(now)
-                        if (failureTimestamps.size >= config.failureThreshold) {
-                            transitionOpenFor(config.timeout)
+                    when {
+                        config.failureRateThreshold != null -> {
+                            // Failure-rate mode: record failure in ring buffer and evaluate
+                            recordOutcomeLocked(failure = true)
+                            evaluateFailureRateLocked()
                         }
-                    } else {
-                        failureCount++
-                        if (failureCount >= config.failureThreshold) {
-                            transitionOpenFor(config.timeout)
+                        slidingWindowMs != null -> {
+                            val now = getTimeMillis()
+                            pruneFailureTimestampsLocked(now)
+                            failureTimestamps.addLast(now)
+                            pruneFailureTimestampsLocked(now)
+                            if (failureTimestamps.size >= config.failureThreshold) {
+                                transitionOpenFor(config.timeout)
+                            }
+                        }
+                        else -> {
+                            failureCount++
+                            if (failureCount >= config.failureThreshold) {
+                                transitionOpenFor(config.timeout)
+                            }
                         }
                     }
                 }
@@ -335,7 +366,40 @@ class DefaultCircuitBreaker(
         if (slidingWindowMs != null) {
             failureTimestamps.clear()
         }
+        // Ring buffer is intentionally NOT cleared here — it is cleared on CLOSED transition only
         transitionTo(CircuitState.OPEN)
+    }
+
+    /**
+     * Records a single outcome (success=false or failure=true) into [ringBuffer].
+     * Evicts the oldest entry when the buffer would exceed [CircuitBreakerConfig.minimumNumberOfCalls].
+     * Also updates [failureCount] to reflect the current number of failures in the buffer.
+     * Must be called with [mutex] held.
+     */
+    private fun recordOutcomeLocked(failure: Boolean) {
+        val capacity = config.minimumNumberOfCalls
+        if (ringBuffer.size >= capacity) {
+            val evicted = ringBuffer.removeFirst()
+            if (evicted) failureCount = maxOf(0, failureCount - 1)
+        }
+        ringBuffer.addLast(failure)
+        if (failure) failureCount++
+    }
+
+    /**
+     * Evaluates the current failure rate and opens the circuit if it meets or exceeds
+     * [CircuitBreakerConfig.failureRateThreshold]. Only acts when the ring buffer is full
+     * (i.e., [ringBuffer].size == [CircuitBreakerConfig.minimumNumberOfCalls]).
+     * Must be called with [mutex] held.
+     */
+    private fun evaluateFailureRateLocked() {
+        val threshold = config.failureRateThreshold ?: return
+        val capacity = config.minimumNumberOfCalls
+        if (ringBuffer.size < capacity) return
+        val rate = failureCount.toDouble() / capacity * 100.0
+        if (rate >= threshold) {
+            transitionOpenFor(config.timeout)
+        }
     }
 
     /** Must be called with [mutex] held. Updates [failureCount] to the number of timestamps in the window. */

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
@@ -310,6 +310,8 @@ fun resilient(
             halfOpenMaxCalls = cfg.halfOpenMaxCalls
             shouldRecordFailure = cfg.shouldRecordFailure
             slidingWindow = cfg.slidingWindow
+            failureRateThreshold = cfg.failureRateThreshold
+            minimumNumberOfCalls = cfg.minimumNumberOfCalls
             onStateChange = { state -> cfg.onStateChange(state) }
         }
         DefaultCircuitBreaker(copy) { new, old ->

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerFailureRateTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerFailureRateTest.kt
@@ -52,7 +52,7 @@ class CircuitBreakerFailureRateTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `given 10 calls with 4 failures (40 percent) when threshold is 50 percent then circuit stays CLOSED`() =
+    fun `given 10 calls with 4 failures 40 percent when threshold is 50 percent then circuit stays CLOSED`() =
         runTest {
             val cfg = CircuitBreakerConfig().apply {
                 failureRateThreshold = 50.0
@@ -78,7 +78,7 @@ class CircuitBreakerFailureRateTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `given 10 calls with 5 failures (50 percent) when threshold is 50 percent then circuit opens`() =
+    fun `given 10 calls with 5 failures 50 percent when threshold is 50 percent then circuit opens`() =
         runTest {
             val cfg = CircuitBreakerConfig().apply {
                 failureRateThreshold = 50.0
@@ -139,7 +139,7 @@ class CircuitBreakerFailureRateTest {
     // ──────────────────────────────────────────────────────────────────────────
 
     @Test
-    fun `given failureRateThreshold null when 5 consecutive failures then circuit opens (no regression)`() =
+    fun `given failureRateThreshold null when 5 consecutive failures then circuit opens no regression`() =
         runTest {
             val cfg = CircuitBreakerConfig().apply {
                 failureRateThreshold = null

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerFailureRateTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerFailureRateTest.kt
@@ -1,0 +1,241 @@
+package com.santimattius.resilient.circuitbreaker
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Unit tests for the failure-rate (count-based sliding window) mode of [DefaultCircuitBreaker].
+ *
+ * Scenarios from spec:
+ * S1 – CLOSED when < minimumNumberOfCalls recorded (even if all fail)
+ * S2 – CLOSED when minimumNumberOfCalls reached but rate < threshold
+ * S3 – OPEN when minimumNumberOfCalls reached and rate >= threshold
+ * S4 – Half-open recovery after rate-triggered open
+ * S5 – Consecutive mode still works when failureRateThreshold == null
+ * S6 – Ring buffer slides (old entries evicted)
+ * S7 – Both failureRateThreshold and slidingWindow set → IllegalArgumentException
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class CircuitBreakerFailureRateTest {
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S1 – below minimumNumberOfCalls: circuit stays CLOSED even with all failures
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given failureRateThreshold when fewer than minimumNumberOfCalls recorded then circuit stays CLOSED`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = 50.0
+                minimumNumberOfCalls = 10
+                successThreshold = 1
+                timeout = 60.seconds
+                halfOpenMaxCalls = 1
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // Record 9 failures — all fail but minimum not reached
+            repeat(9) {
+                assertFailsWith<IllegalStateException> { cb.execute { error("boom") } }
+            }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S2 – minimumNumberOfCalls reached but rate below threshold: stays CLOSED
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given 10 calls with 4 failures (40 percent) when threshold is 50 percent then circuit stays CLOSED`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = 50.0
+                minimumNumberOfCalls = 10
+                successThreshold = 1
+                timeout = 60.seconds
+                halfOpenMaxCalls = 1
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // 6 successes
+            repeat(6) { cb.execute { "ok" } }
+            // 4 failures
+            repeat(4) {
+                assertFailsWith<IllegalStateException> { cb.execute { error("boom") } }
+            }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S3 – exactly at threshold (50%): circuit opens
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given 10 calls with 5 failures (50 percent) when threshold is 50 percent then circuit opens`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = 50.0
+                minimumNumberOfCalls = 10
+                successThreshold = 1
+                timeout = 60.seconds
+                halfOpenMaxCalls = 1
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // 5 successes + 5 failures = 50% rate
+            repeat(5) { cb.execute { "ok" } }
+            repeat(4) {
+                assertFailsWith<IllegalStateException> { cb.execute { error("boom") } }
+            }
+            // 10th call (5th failure) — should trip the breaker
+            assertFailsWith<IllegalStateException> { cb.execute { error("boom") } }
+
+            assertEquals(CircuitState.OPEN, cb.state.value)
+            assertFailsWith<CircuitBreakerOpenException> { cb.execute { "never" } }
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S4 – half-open recovery after rate-triggered open
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given OPEN due to failure rate when timeout elapses then half-open probe succeeds and transitions to CLOSED`() =
+        runTest {
+            val ts = TestTimeSource()
+            ts.setTime(1000L)
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = 50.0
+                minimumNumberOfCalls = 4
+                successThreshold = 2
+                timeout = 10.milliseconds
+                halfOpenMaxCalls = 3
+            }
+            val cb = DefaultCircuitBreaker(cfg, ts)
+
+            // Trip the breaker: 4 calls, 2 failures = 50%
+            repeat(2) { cb.execute { "ok" } }
+            repeat(2) { assertFailsWith<IllegalStateException> { cb.execute { error("trip") } } }
+            assertEquals(CircuitState.OPEN, cb.state.value)
+
+            // Advance past timeout
+            ts.advanceTimeBy(15L)
+
+            // Two successive probe successes → CLOSED
+            cb.execute { "probe-1" }
+            cb.execute { "probe-2" }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S5 – consecutive mode unchanged when failureRateThreshold == null
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given failureRateThreshold null when 5 consecutive failures then circuit opens (no regression)`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = null
+                failureThreshold = 5
+                successThreshold = 1
+                timeout = 60.seconds
+                halfOpenMaxCalls = 1
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            repeat(5) {
+                assertFailsWith<IllegalStateException> { cb.execute { error("boom") } }
+            }
+
+            assertEquals(CircuitState.OPEN, cb.state.value)
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S6 – ring buffer slides: old entries are evicted
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given circuit recovered to CLOSED when next window has 2 of 5 failures then circuit stays CLOSED`() =
+        runTest {
+            val ts = TestTimeSource()
+            ts.setTime(1000L)
+            val cfg = CircuitBreakerConfig().apply {
+                failureRateThreshold = 60.0
+                minimumNumberOfCalls = 5
+                successThreshold = 1
+                timeout = 10.milliseconds
+                halfOpenMaxCalls = 1
+            }
+            val cb = DefaultCircuitBreaker(cfg, ts)
+
+            // First window: 4 failures, 1 success = 80% → opens
+            repeat(4) { assertFailsWith<IllegalStateException> { cb.execute { error("fail") } } }
+            cb.execute { "ok" }
+            assertEquals(CircuitState.OPEN, cb.state.value)
+
+            // Recover: advance past timeout, one probe success → CLOSED
+            ts.advanceTimeBy(15L)
+            cb.execute { "probe" }
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+
+            // Second window: 2 failures, 3 successes = 40% → stays CLOSED
+            repeat(3) { cb.execute { "ok" } }
+            repeat(2) { assertFailsWith<IllegalStateException> { cb.execute { error("fail") } } }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // S7 – combining failureRateThreshold + slidingWindow → IllegalArgumentException
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given both failureRateThreshold and slidingWindow set then IllegalArgumentException is thrown`() {
+        assertFailsWith<IllegalArgumentException> {
+            CircuitBreakerConfig().apply {
+                failureRateThreshold = 50.0
+                slidingWindow = 30.seconds
+            }
+            // Validation happens in DefaultCircuitBreaker init
+            DefaultCircuitBreaker(
+                CircuitBreakerConfig().apply {
+                    failureRateThreshold = 50.0
+                    slidingWindow = 30.seconds
+                }
+            )
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Extra triangulation: out-of-range failureRateThreshold
+    // ──────────────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `given failureRateThreshold above 100 when creating circuit breaker then IllegalArgumentException is thrown`() {
+        assertFailsWith<IllegalArgumentException> {
+            DefaultCircuitBreaker(
+                CircuitBreakerConfig().apply {
+                    failureRateThreshold = 101.0
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `given failureRateThreshold below 0 when creating circuit breaker then IllegalArgumentException is thrown`() {
+        assertFailsWith<IllegalArgumentException> {
+            DefaultCircuitBreaker(
+                CircuitBreakerConfig().apply {
+                    failureRateThreshold = -1.0
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description
Adds `failureRateThreshold` + `minimumNumberOfCalls` to `CircuitBreakerConfig`. Count-based ring buffer. Coexists with existing consecutive and time-window modes.