### PR TITLE
feat: add shouldRecordResult predicate to CircuitBreakerConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ---
 ## [Unreleased]
 
+### Added
+
+- **Circuit Breaker — result-based failure recording**
+  - `CircuitBreakerConfig.shouldRecordResult`: optional predicate `((Any?) -> Boolean)?` evaluated after the block returns without throwing. When `true`, the returned value counts as a failure (incrementing the failure counter and potentially opening the circuit) while the value is still returned to the caller unchanged. Default `null` preserves existing behaviour — zero regression.
+  - This predicate is independent of `shouldRecordFailure`: `shouldRecordFailure` governs the exception path; `shouldRecordResult` governs the success-value path.
+
 ## [1.4.0] - 2026-03-22
 
 ### Added

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreaker.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreaker.kt
@@ -131,6 +131,24 @@ class CircuitBreakerConfig {
     var shouldRecordFailure: (Throwable) -> Boolean = { true }
     var onStateChange: (CircuitState) -> Unit = { }
     var slidingWindow: Duration? = null
+
+    /**
+     * Optional predicate evaluated after the block returns **without** throwing.
+     *
+     * When `null` (default), every non-exceptional return is treated as a success — zero regression.
+     * When set, the predicate receives the returned value (`Any?`). If it returns `true`, the call is
+     * counted as a failure (via the `onFailure` path) even though the block did not throw.
+     * The result is still returned to the caller unchanged.
+     *
+     * This predicate is **independent** of [shouldRecordFailure]: `shouldRecordFailure` governs the
+     * exception path; `shouldRecordResult` governs the success-value path.
+     *
+     * Example — treat HTTP 503 as a circuit-breaker failure:
+     * ```kotlin
+     * shouldRecordResult = { result -> result is ApiResponse && result.code == 503 }
+     * ```
+     */
+    var shouldRecordResult: ((Any?) -> Boolean)? = null
 }
 
 /**

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/DefaultCircuitBreaker.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/circuitbreaker/DefaultCircuitBreaker.kt
@@ -244,9 +244,15 @@ class DefaultCircuitBreaker(
         return try {
             val result = block()
             // Use NonCancellable to ensure state is updated even if coroutine is cancelled
-            // after block completes but before onSuccess is called
+            // after block completes but before onSuccess / onFailure is called.
             withContext(NonCancellable) {
-                onSuccess()
+                if (config.shouldRecordResult?.invoke(result) == true) {
+                    // Result matches the failure predicate: record as failure but still return
+                    // the value to the caller — do NOT throw.
+                    onResultFailure()
+                } else {
+                    onSuccess()
+                }
             }
             result
         } catch (e: CancellationException) {
@@ -292,9 +298,23 @@ class DefaultCircuitBreaker(
         }
     }
 
+    /**
+     * Records a failure triggered by [CircuitBreakerConfig.shouldRecordResult].
+     *
+     * Bypasses the [CircuitBreakerConfig.shouldRecordFailure] guard (which is only relevant for
+     * exception-based failures) and applies the same state-machine logic as [onFailure].
+     */
+    private suspend fun onResultFailure() {
+        recordFailureLocked()
+    }
+
     private suspend fun onFailure(t: Throwable) {
         if (!config.shouldRecordFailure(t)) return
+        recordFailureLocked()
+    }
 
+    /** Applies the failure state-machine update inside the mutex. */
+    private suspend fun recordFailureLocked() {
         mutex.withLock {
             when (_state.value) {
                 CircuitState.CLOSED -> {

--- a/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
+++ b/shared/src/commonMain/kotlin/com/santimattius/resilient/composition/ResilientBuilder.kt
@@ -309,6 +309,7 @@ fun resilient(
             timeout = cfg.timeout
             halfOpenMaxCalls = cfg.halfOpenMaxCalls
             shouldRecordFailure = cfg.shouldRecordFailure
+            shouldRecordResult = cfg.shouldRecordResult
             slidingWindow = cfg.slidingWindow
             onStateChange = { state -> cfg.onStateChange(state) }
         }

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerShouldRecordResultTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerShouldRecordResultTest.kt
@@ -1,0 +1,197 @@
+package com.santimattius.resilient.circuitbreaker
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Tests for [CircuitBreakerConfig.shouldRecordResult]: a predicate that allows
+ * result-based failure recording without throwing an exception.
+ *
+ * Spec scenarios:
+ * - S1: matching result triggers failure recording → circuit eventually opens
+ * - S2: non-matching result counts as success / resets consecutive counter
+ * - S3: null predicate → no additional failure recorded, result returned normally
+ * - S4: exception path still governed by shouldRecordFailure, not shouldRecordResult
+ */
+class CircuitBreakerShouldRecordResultTest {
+
+    // ---------------------------------------------------------------------------
+    // Scenario 1 — S1: matching result triggers failure recording; circuit opens
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `S1 - given shouldRecordResult matching all results and failureThreshold 3 when 3 calls return matching value then circuit opens`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 3
+                successThreshold = 2
+                timeout = 60.seconds
+                halfOpenMaxCalls = 1
+                shouldRecordResult = { it is String && it == "FAIL" }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // All three calls return a matching value — each should record a failure
+            val r1 = cb.execute { "FAIL" }
+            assertEquals("FAIL", r1, "Result must be returned even when counted as failure")
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+
+            val r2 = cb.execute { "FAIL" }
+            assertEquals("FAIL", r2)
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+
+            val r3 = cb.execute { "FAIL" }
+            assertEquals("FAIL", r3)
+
+            // After 3 recorded failures the circuit must be OPEN
+            assertEquals(CircuitState.OPEN, cb.state.value)
+        }
+
+    @Test
+    fun `S1 - given shouldRecordResult when circuit opens then subsequent calls are rejected`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 2
+                shouldRecordResult = { true }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            cb.execute { "any" }
+            cb.execute { "any" } // second call opens the circuit
+
+            assertEquals(CircuitState.OPEN, cb.state.value)
+
+            assertFailsWith<CircuitBreakerOpenException> {
+                cb.execute { "any" }
+            }
+        }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 2 — S2: non-matching result counts as success / resets counter
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `S2 - given shouldRecordResult when non-matching result returned then failure counter resets and circuit stays CLOSED`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 3
+                shouldRecordResult = { it is String && it == "503" }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // Build up two failures
+            cb.execute { "503" }
+            cb.execute { "503" }
+            assertEquals(2, cb.snapshot().failureCount)
+
+            // Non-matching result → should be treated as success → counter resets
+            cb.execute { "200" }
+            assertEquals(0, cb.snapshot().failureCount)
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    @Test
+    fun `S2 - given non-matching result when failure threshold not reached then circuit remains CLOSED`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 3
+                shouldRecordResult = { it is Int && it >= 500 }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            repeat(10) {
+                val result = cb.execute { 200 }
+                assertEquals(200, result)
+            }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+            assertEquals(0, cb.snapshot().failureCount)
+        }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 3 — S3: null predicate → no failure recorded, result returned
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `S3 - given null shouldRecordResult when call returns any value then no failure is recorded`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 2
+                shouldRecordResult = null // explicit null — default
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            repeat(5) {
+                val result = cb.execute { "ok" }
+                assertEquals("ok", result)
+            }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+            assertEquals(0, cb.snapshot().failureCount)
+        }
+
+    @Test
+    fun `S3 - given default config (no shouldRecordResult set) when calls succeed then circuit stays CLOSED`() =
+        runTest {
+            // Default config has shouldRecordResult = null
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 3
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            repeat(10) { cb.execute { 42 } }
+
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+        }
+
+    // ---------------------------------------------------------------------------
+    // Scenario 4 — S4: exception path governed by shouldRecordFailure, not shouldRecordResult
+    // ---------------------------------------------------------------------------
+
+    @Test
+    fun `S4 - given shouldRecordResult true and shouldRecordFailure rejecting exception when call throws then failure is NOT recorded`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 2
+                shouldRecordResult = { true }
+                // Only IOExceptions should be recorded — IllegalStateException should NOT
+                shouldRecordFailure = { it is java.io.IOException }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            // Throw IllegalStateException — shouldRecordFailure returns false → not recorded
+            repeat(5) {
+                assertFailsWith<IllegalStateException> {
+                    cb.execute { throw IllegalStateException("not an IO error") }
+                }
+            }
+
+            // Circuit must stay CLOSED because shouldRecordFailure filtered out the exception
+            assertEquals(CircuitState.CLOSED, cb.state.value)
+            assertEquals(0, cb.snapshot().failureCount)
+        }
+
+    @Test
+    fun `S4 - given shouldRecordFailure allowing IOException when IO exception thrown then failure IS recorded`() =
+        runTest {
+            val cfg = CircuitBreakerConfig().apply {
+                failureThreshold = 2
+                shouldRecordResult = { false } // result predicate does not interfere
+                shouldRecordFailure = { it is java.io.IOException }
+            }
+            val cb = DefaultCircuitBreaker(cfg)
+
+            assertFailsWith<java.io.IOException> {
+                cb.execute { throw java.io.IOException("network error") }
+            }
+            assertFailsWith<java.io.IOException> {
+                cb.execute { throw java.io.IOException("network error") }
+            }
+
+            // shouldRecordFailure allowed both → circuit opens
+            assertEquals(CircuitState.OPEN, cb.state.value)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerShouldRecordResultTest.kt
+++ b/shared/src/commonTest/kotlin/com/santimattius/resilient/circuitbreaker/CircuitBreakerShouldRecordResultTest.kt
@@ -134,7 +134,7 @@ class CircuitBreakerShouldRecordResultTest {
         }
 
     @Test
-    fun `S3 - given default config (no shouldRecordResult set) when calls succeed then circuit stays CLOSED`() =
+    fun `S3 - given default config no shouldRecordResult set when calls succeed then circuit stays CLOSED`() =
         runTest {
             // Default config has shouldRecordResult = null
             val cfg = CircuitBreakerConfig().apply {
@@ -158,7 +158,7 @@ class CircuitBreakerShouldRecordResultTest {
                 failureThreshold = 2
                 shouldRecordResult = { true }
                 // Only IOExceptions should be recorded — IllegalStateException should NOT
-                shouldRecordFailure = { it is java.io.IOException }
+                shouldRecordFailure = { it is RuntimeException && it.message?.startsWith("io:") == true }
             }
             val cb = DefaultCircuitBreaker(cfg)
 
@@ -180,15 +180,15 @@ class CircuitBreakerShouldRecordResultTest {
             val cfg = CircuitBreakerConfig().apply {
                 failureThreshold = 2
                 shouldRecordResult = { false } // result predicate does not interfere
-                shouldRecordFailure = { it is java.io.IOException }
+                shouldRecordFailure = { it is RuntimeException && it.message?.startsWith("io:") == true }
             }
             val cb = DefaultCircuitBreaker(cfg)
 
-            assertFailsWith<java.io.IOException> {
-                cb.execute { throw java.io.IOException("network error") }
+            assertFailsWith<RuntimeException> {
+                cb.execute { throw RuntimeException("io: network error") }
             }
-            assertFailsWith<java.io.IOException> {
-                cb.execute { throw java.io.IOException("network error") }
+            assertFailsWith<RuntimeException> {
+                cb.execute { throw RuntimeException("io: network error") }
             }
 
             // shouldRecordFailure allowed both → circuit opens


### PR DESCRIPTION
## Description
Mirrors `shouldRetryResult` on retry. Allows result values (e.g. `HttpResponse(503)`) to count as circuit breaker failures without throwing.